### PR TITLE
add basic CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: goto-bus-stop/setup-zig@v1
+        with:
+          version: master
+      - name: fmt
+        run: zig fmt --check *.zig src/*.zig
+      - name: test
+        run: zig build test


### PR DESCRIPTION
This PR lets GitHub Actions run basic checking commands including `zig fmt` and `zig build test` on every push.