### PR TITLE
chore: move to zig 0.11 new build API.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,17 +1,26 @@
 const std = @import("std");
 
 pub fn build(b: *std.build.Builder) void {
-    // Standard release options allow the person running `zig build` to select
-    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
-    const mode = b.standardReleaseOptions();
+    const target = b.standardTargetOptions(.{});
 
-    const lib = b.addStaticLibrary("zig-deque", "src/deque.zig");
-    lib.setBuildMode(mode);
-    lib.install();
+    const optimize = b.standardOptimizeOption(.{});
 
-    const main_tests = b.addTest("src/deque.zig");
-    main_tests.setBuildMode(mode);
+    const lib = b.addStaticLibrary(.{
+        .name = "zig-deque",
+        .root_source_file = .{ .path = "src/deque.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+    b.installArtifact(lib);
+
+    const main_tests = b.addTest(.{
+        .root_source_file = .{ .path = "src/deque.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const run_main_tests = b.addRunArtifact(main_tests);
 
     const test_step = b.step("test", "Run library tests");
-    test_step.dependOn(&main_tests.step);
+    test_step.dependOn(&run_main_tests.step);
 }

--- a/build.zig
+++ b/build.zig
@@ -5,12 +5,18 @@ pub fn build(b: *std.build.Builder) void {
 
     const optimize = b.standardOptimizeOption(.{});
 
+    _ = b.addModule("zig-deque", .{
+        .source_file = .{ .path = "src/deque.zig" },
+        .dependencies = &.{},
+    });
+
     const lib = b.addStaticLibrary(.{
         .name = "zig-deque",
         .root_source_file = .{ .path = "src/deque.zig" },
         .target = target,
         .optimize = optimize,
     });
+
     b.installArtifact(lib);
 
     const main_tests = b.addTest(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,5 @@
+.{
+    .name = "zig-deque",
+    .version = "0.1.0",
+    .dependencies = .{},
+}

--- a/src/deque.zig
+++ b/src/deque.zig
@@ -40,7 +40,7 @@ pub fn Deque(comptime T: type) type {
         /// Deinitialize with `deinit`.
         pub fn initCapacity(allocator: Allocator, capacity: usize) Allocator.Error!Self {
             const effective_cap =
-                math.ceilPowerOfTwo(usize, math.max(capacity +| 1, MINIMUM_CAPACITY + 1)) catch
+                math.ceilPowerOfTwo(usize, @max(capacity +| 1, MINIMUM_CAPACITY + 1)) catch
                 math.ceilPowerOfTwoAssert(usize, INITIAL_CAPACITY + 1);
             const buf = try allocator.alloc(T, effective_cap);
             return Self{


### PR DESCRIPTION
- Migrate to 0.11 build API.  See here https://devlog.hexops.com/2023/zig-0-11-breaking-build-changes/.
- `std.math.max` is deprecated. 

Tested on 0.11.0-dev.4006+bf827d0b5.

