### PR TITLE
chore: compact latest zig v0.12.0-dev.1819+5c1428ea9

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,4 +2,5 @@
     .name = "zig-deque",
     .version = "0.1.0",
     .dependencies = .{},
+    .paths = .{""},
 }

--- a/src/deque.zig
+++ b/src/deque.zig
@@ -259,7 +259,7 @@ pub fn Deque(comptime T: type) type {
         fn copyNonOverlapping(self: *Self, dest: usize, src: usize, length: usize) void {
             assert(dest + length <= self.cap());
             assert(src + length <= self.cap());
-            mem.copy(T, self.buf[dest .. dest + length], self.buf[src .. src + length]);
+            @memcpy(self.buf[dest .. dest + length], self.buf[src .. src + length]);
         }
 
         fn wrapAdd(self: Self, idx: usize, addend: usize) usize {


### PR DESCRIPTION
Also support zig 0.11