### PR TITLE
0.14.1 update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.13.0
+          version: 0.14.0
       - name: fmt
         run: zig fmt --check *.zig src/*.zig
       - name: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.14.0
+          version: 0.14.1
       - name: fmt
         run: zig fmt --check *.zig src/*.zig
       - name: test

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,11 @@
 .{
-    .name = "zig-deque",
+    .name = .zig_deque,
+    .fingerprint = 0xa500e2834e68a291,
     .version = "0.1.0",
-    .dependencies = .{},
-    .paths = .{""},
+    .paths = .{
+        "LICENSE",
+        "src/",
+        "build.zig",
+        "build.zig.zon",
+    },
 }

--- a/src/deque.zig
+++ b/src/deque.zig
@@ -41,7 +41,7 @@ pub fn Deque(comptime T: type) type {
         pub fn initCapacity(allocator: Allocator, capacity: usize) Allocator.Error!Self {
             const effective_cap =
                 math.ceilPowerOfTwo(usize, @max(capacity +| 1, MINIMUM_CAPACITY + 1)) catch
-                math.ceilPowerOfTwoAssert(usize, INITIAL_CAPACITY + 1);
+                    math.ceilPowerOfTwoAssert(usize, INITIAL_CAPACITY + 1);
             const buf = try allocator.alloc(T, effective_cap);
             return Self{
                 .tail = 0,


### PR DESCRIPTION
Update to Zig 0.14.1 with package configuration changes

- Bump CI Zig version from 0.13.0 to 0.14.1
- Update build.zig.zon for Zig 0.14 compatibility with underscored package name
- Apply code formatting for Zig 0.14.x standards

Credit to @asier-ochoa for the original contribution in #16