### PR TITLE
Zig 0.15.1 update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.14.1
+          version: 0.15.1
       - name: fmt
         run: zig fmt --check *.zig src/*.zig
       - name: test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-zig-cache/
+.zig-cache/
 zig-out/

--- a/build.zig
+++ b/build.zig
@@ -2,27 +2,25 @@ const std = @import("std");
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
-
     const optimize = b.standardOptimizeOption(.{});
 
-    _ = b.addModule("zig-deque", .{
-        .root_source_file = b.path("src/deque.zig"),
-        .imports = &.{},
-    });
-
-    const lib = b.addStaticLibrary(.{
-        .name = "zig-deque",
+    const mod = b.addModule("zig-deque", .{
         .root_source_file = b.path("src/deque.zig"),
         .target = target,
         .optimize = optimize,
+        .imports = &.{},
+    });
+
+    const lib = b.addLibrary(.{
+        .name = "zig-deque",
+        .root_module = mod,
+        .linkage = .static,
     });
 
     b.installArtifact(lib);
 
     const main_tests = b.addTest(.{
-        .root_source_file = b.path("src/deque.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = mod,
     });
 
     const run_main_tests = b.addRunArtifact(main_tests);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,6 +2,7 @@
     .name = .zig_deque,
     .fingerprint = 0xa500e2834e68a291,
     .version = "0.1.0",
+    .minimum_zig_version = "0.15.1",
     .paths = .{
         "LICENSE",
         "src/",

--- a/src/deque.zig
+++ b/src/deque.zig
@@ -160,9 +160,9 @@ pub fn Deque(comptime T: type) type {
             };
         }
 
-        pub fn format(self: *const Self, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+        pub fn format(self: *const Self, writer: *std.Io.Writer) !void {
             try writer.writeAll("Deque(");
-            try std.fmt.format(writer, "{}", .{T});
+            try writer.print("{}", .{T});
             try writer.writeAll(") { .buf = [");
 
             var it = self.iterator();
@@ -170,11 +170,11 @@ pub fn Deque(comptime T: type) type {
             while (it.next()) |val| try writer.print(", {any}", .{val});
 
             try writer.writeAll("], .head = ");
-            try std.fmt.format(writer, "{}", .{self.head});
+            try writer.print("{}", .{self.head});
             try writer.writeAll(", .tail = ");
-            try std.fmt.format(writer, "{}", .{self.tail});
+            try writer.print("{}", .{self.tail});
             try writer.writeAll(", .len = ");
-            try std.fmt.format(writer, "{}", .{self.len()});
+            try writer.print("{}", .{self.len()});
             try writer.writeAll(" }");
         }
 
@@ -400,7 +400,7 @@ test "format" {
     try deque.pushBack(69);
     try deque.pushBack(420);
 
-    std.debug.print("{}\n", .{deque});
+    std.debug.print("{f}\n", .{deque});
 }
 
 test "nextBack" {


### PR DESCRIPTION
This PR updates the codebase for Zig 0.15.1.

- update `build.zig`
- adjust `src/deque.zig` for the new Writer API
- add `minimum_zig_version` to `build.zig.zon`
- update `ci.yml`; use Zig v0.15.1
- fix `.gitignore`: `zig-cache` → `.zig-cache`